### PR TITLE
Switch from dgrijalva/jwt-go to golang-jwt/jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS KMS adapter for dgrijalva/jwt-go library
 This library provides an AWS KMS(Key Management Service) adapter to be used with the popular GoLang JWT library
-[dgrijalva/jwt-go](https://github.com/dgrijalva/jwt-go).
+[golang-jwt/jwt-go](https://github.com/golang-jwt/jwt).
 
 It will *Sign* a JWT token using an assymetric key stored in AWS KMS.
 
@@ -27,6 +27,10 @@ Shouting out to:
 * [dgrijalva](https://github.com/dgrijalva)
 
   for the easy to extend GoLang JWT Library
+
+* [golang-jwt](https://github.com/golang-jwt)
+
+  for taking over the project from dgrijalva
 
 * [Mikael Gidmark](https://stackoverflow.com/users/300598/mikael-gidmark)
 

--- a/example/example.go
+++ b/example/example.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 	"github.com/matelang/jwt-go-aws-kms/v2/jwtkms"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.6.0
 	github.com/aws/aws-sdk-go-v2/config v1.3.0
 	github.com/aws/aws-sdk-go-v2/service/kms v1.3.2
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/golang-jwt/jwt v3.2.1+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.4.1/go.mod h1:G9osDWA52WQ38BDcj65VY1
 github.com/aws/smithy-go v1.4.0 h1:3rsQpgRe+OoQgJhEwGNpIkosl0fJLdmQqF4gSFRjg+4=
 github.com/aws/smithy-go v1.4.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
+github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=

--- a/jwtkms/init.go
+++ b/jwtkms/init.go
@@ -11,7 +11,7 @@ package jwtkms
 import (
 	"crypto"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 var (

--- a/jwtkms/kms_ecdsa_signingmethod.go
+++ b/jwtkms/kms_ecdsa_signingmethod.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/kms/types"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 // ECDSASigningMethod is an ECDSA implementation of the SigningMethod interface that uses KMS to Sign/Verify JWTs.

--- a/jwtkms/kms_rsa_signingmethod.go
+++ b/jwtkms/kms_rsa_signingmethod.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kms"
 	"github.com/aws/aws-sdk-go-v2/service/kms/types"
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 // RSASigningMethod is an RSA implementation of the SigningMethod interface that uses KMS to Sign/Verify JWTs.


### PR DESCRIPTION
As documented in https://github.com/dgrijalva/jwt-go, `dgrijalva/jwt-go` is going to be maintained as `golang-jwt/jwt` in the future. This PR does nothing but to make this library "future-proof" by switching dependencies.