### PR TITLE
common: Add test to ensure that `*kms.Client` is a `KMSClient`

### DIFF
--- a/jwtkms/common_test.go
+++ b/jwtkms/common_test.go
@@ -1,0 +1,5 @@
+package jwtkms
+
+import "github.com/aws/aws-sdk-go-v2/service/kms"
+
+var _ KMSClient = &kms.Client{}


### PR DESCRIPTION
Add a check that the `KMSClient` interface is implemented by `*kms.Client` to ensure that the interfaces do not diverge.