### PR TITLE
jwtkms: Add a KMS partial mock and jwtkms tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.17.5
 	github.com/aws/aws-sdk-go-v2/service/kms v1.18.9
 	github.com/golang-jwt/jwt/v4 v4.4.2
+	github.com/google/uuid v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/jwtkms/internal/mockkms/mockkms.go
+++ b/jwtkms/internal/mockkms/mockkms.go
@@ -1,0 +1,230 @@
+// Package mockkms provides a partial implementation of AWS' KMS interface
+// sufficient to satisfy the KMSClient interface.
+package mockkms
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"fmt"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+	"github.com/google/uuid"
+)
+
+// KeyType describes the type of a key.
+type KeyType int
+
+const (
+	KeyTypeECCNISTP256 KeyType = iota
+	KeyTypeECCNISTP384
+	KeyTypeECCNISTP521
+	KeyTypeRSA2048
+)
+
+// MockKMS implements the KMSClient interface backed by in-memory storage. It
+// is safe for concurrent use.
+type MockKMS struct {
+	mu   sync.Mutex
+	keys map[string]interface{}
+}
+
+// NewMockKMS constructs a new MockKMS instance.
+func NewMockKMS() *MockKMS {
+	return &MockKMS{
+		keys: make(map[string]interface{}),
+	}
+}
+
+// GenerateKey generates a key of the type described by kt and returns the
+// KeyId which can be used by subsequent calls to refer to the generated key.
+func (k *MockKMS) GenerateKey(kt KeyType) (string, error) {
+	var err error
+	var key interface{}
+	switch kt {
+	case KeyTypeECCNISTP256, KeyTypeECCNISTP384, KeyTypeECCNISTP521:
+		key, err = generateECCKey(kt)
+
+	case KeyTypeRSA2048:
+		key, err = generateRSAKey(kt)
+
+	default:
+		return "", fmt.Errorf("unknown key type: %v", kt)
+	}
+	if err != nil {
+		return "", fmt.Errorf("generating key: %w", err)
+	}
+
+	id := uuid.NewString()
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.keys[id] = key
+
+	return id, nil
+}
+
+var keyTypeECCCurves = map[KeyType]elliptic.Curve{
+	KeyTypeECCNISTP256: elliptic.P256(),
+	KeyTypeECCNISTP384: elliptic.P384(),
+	KeyTypeECCNISTP521: elliptic.P521(),
+}
+
+func generateECCKey(kt KeyType) (*ecdsa.PrivateKey, error) {
+	pk, err := ecdsa.GenerateKey(keyTypeECCCurves[kt], rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generating key: %w", err)
+	}
+	return pk, nil
+}
+
+var keyTypeRSABits = map[KeyType]int{
+	KeyTypeRSA2048: 2048,
+}
+
+func generateRSAKey(kt KeyType) (*rsa.PrivateKey, error) {
+	pk, err := rsa.GenerateKey(rand.Reader, keyTypeRSABits[kt])
+	if err != nil {
+		return nil, fmt.Errorf("generating key: %v", err)
+	}
+	return pk, nil
+}
+
+func (k *MockKMS) getKey(id string) (interface{}, error) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	key, ok := k.keys[id]
+	if !ok {
+		return nil, fmt.Errorf("no such key: %v", id)
+	}
+	return key, nil
+}
+
+func (k *MockKMS) Sign(_ context.Context, in *kms.SignInput, _ ...func(*kms.Options)) (*kms.SignOutput, error) {
+	key, err := k.getKey(*in.KeyId)
+	if err != nil {
+		return nil, err
+	}
+
+	if in.MessageType != types.MessageTypeDigest {
+		return nil, fmt.Errorf("unsupported message type: %v", in.MessageType)
+	}
+
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		return signECSDA(key, in)
+
+	case *rsa.PrivateKey:
+		return signRSA(key, in)
+
+	default:
+		panic("unreachable")
+	}
+}
+
+var ecdsaSigningAlgorithms = map[types.SigningAlgorithmSpec]bool{
+	types.SigningAlgorithmSpecEcdsaSha256: true,
+	types.SigningAlgorithmSpecEcdsaSha384: true,
+	types.SigningAlgorithmSpecEcdsaSha512: true,
+}
+
+func signECSDA(key *ecdsa.PrivateKey, in *kms.SignInput) (*kms.SignOutput, error) {
+	if !ecdsaSigningAlgorithms[in.SigningAlgorithm] {
+		return nil, fmt.Errorf("unknowning signing algorithm: %v", in.SigningAlgorithm)
+	}
+
+	sig, err := key.Sign(rand.Reader, in.Message, nil)
+	if err != nil {
+		return nil, fmt.Errorf("signing message: %w", err)
+	}
+
+	return &kms.SignOutput{
+		Signature: sig,
+	}, nil
+}
+
+var rsaHashAlgorithms = map[types.SigningAlgorithmSpec]crypto.Hash{
+	types.SigningAlgorithmSpecRsassaPkcs1V15Sha256: crypto.SHA256,
+	types.SigningAlgorithmSpecRsassaPkcs1V15Sha384: crypto.SHA384,
+	types.SigningAlgorithmSpecRsassaPkcs1V15Sha512: crypto.SHA512,
+}
+
+func signRSA(key *rsa.PrivateKey, in *kms.SignInput) (*kms.SignOutput, error) {
+	hash, ok := rsaHashAlgorithms[in.SigningAlgorithm]
+	if !ok {
+		return nil, fmt.Errorf("unknown signing algorithm: %v", in.SigningAlgorithm)
+	}
+
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, hash, in.Message)
+	if err != nil {
+		return nil, fmt.Errorf("signing message: %w", err)
+	}
+
+	return &kms.SignOutput{
+		Signature: sig,
+	}, nil
+}
+
+func (k *MockKMS) Verify(ctx context.Context, in *kms.VerifyInput, optFns ...func(*kms.Options)) (*kms.VerifyOutput, error) {
+	key, err := k.getKey(*in.KeyId)
+	if err != nil {
+		return nil, err
+	}
+
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		return &kms.VerifyOutput{
+			SignatureValid: ecdsa.VerifyASN1(&key.PublicKey, in.Message, in.Signature),
+		}, nil
+
+	case *rsa.PrivateKey:
+		return verifyRSA(key, in)
+
+	default:
+		panic("unreachable")
+	}
+}
+
+func verifyRSA(key *rsa.PrivateKey, in *kms.VerifyInput) (*kms.VerifyOutput, error) {
+	hash, ok := rsaHashAlgorithms[in.SigningAlgorithm]
+	if !ok {
+		return nil, fmt.Errorf("unknown signing algorithm: %v", in.SigningAlgorithm)
+	}
+
+	err := rsa.VerifyPKCS1v15(&key.PublicKey, hash, in.Message, in.Signature)
+
+	return &kms.VerifyOutput{
+		SignatureValid: err == nil,
+	}, nil
+}
+
+func (k *MockKMS) GetPublicKey(_ context.Context, in *kms.GetPublicKeyInput, _ ...func(*kms.Options)) (*kms.GetPublicKeyOutput, error) {
+	key, err := k.getKey(*in.KeyId)
+	if err != nil {
+		return nil, err
+	}
+
+	var public interface{}
+	switch key := key.(type) {
+	case *ecdsa.PrivateKey:
+		public = &key.PublicKey
+
+	case *rsa.PrivateKey:
+		public = &key.PublicKey
+	}
+
+	m, err := x509.MarshalPKIXPublicKey(public)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling public key: %w", err)
+	}
+
+	return &kms.GetPublicKeyOutput{
+		PublicKey: m,
+	}, nil
+}

--- a/jwtkms/signingmethod_test.go
+++ b/jwtkms/signingmethod_test.go
@@ -1,0 +1,81 @@
+package jwtkms
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/matelang/jwt-go-aws-kms/v2/jwtkms/internal/mockkms"
+)
+
+func TestSigningMethod(t *testing.T) {
+	tests := []struct {
+		name          string
+		keyType       mockkms.KeyType
+		signingMethod jwt.SigningMethod
+	}{
+		{
+			name:          "ES256",
+			keyType:       mockkms.KeyTypeECCNISTP256,
+			signingMethod: SigningMethodECDSA256,
+		},
+		{
+			name:          "ES384",
+			keyType:       mockkms.KeyTypeECCNISTP384,
+			signingMethod: SigningMethodECDSA384,
+		},
+		{
+			name:          "ES512",
+			keyType:       mockkms.KeyTypeECCNISTP521,
+			signingMethod: SigningMethodECDSA512,
+		},
+		{
+			name:          "RS256",
+			keyType:       mockkms.KeyTypeRSA2048,
+			signingMethod: SigningMethodRS256,
+		},
+		{
+			name:          "RS384",
+			keyType:       mockkms.KeyTypeRSA2048,
+			signingMethod: SigningMethodRS384,
+		},
+		{
+			name:          "RS512",
+			keyType:       mockkms.KeyTypeRSA2048,
+			signingMethod: SigningMethodRS512,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			token := jwt.NewWithClaims(test.signingMethod, &jwt.MapClaims{
+				"claim": "value",
+			})
+
+			kms := mockkms.NewMockKMS()
+			id, err := kms.GenerateKey(test.keyType)
+			if err != nil {
+				t.Fatalf("Error generating key: %v", err)
+			}
+
+			config := NewKMSConfig(kms, id, false)
+			signed, err := token.SignedString(config)
+			if err != nil {
+				t.Fatalf("Error signing token: %v", err)
+			}
+
+			var claims jwt.MapClaims
+			_, err = jwt.ParseWithClaims(signed, &claims, func(*jwt.Token) (interface{}, error) {
+				return NewKMSConfig(kms, id, false), nil
+			})
+			if err != nil {
+				t.Fatalf("Error validating token offline: %v", err)
+			}
+
+			_, err = jwt.ParseWithClaims(signed, &claims, func(*jwt.Token) (interface{}, error) {
+				return NewKMSConfig(kms, id, true), nil
+			})
+			if err != nil {
+				t.Fatalf("Error validating token online: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a new `internal/mockkms` package which provides an implementation of the KMSClient interface backed by in-memory storage. The mock isn't as strict as the real KMS, but does implement the Sign, Verify, and GetPublicKey methods faithfully enough to allow for testing of jwtkms.

This commit also introduces tests for all of the jwtkms signing methods, using the mockkms package to provide the backing implementation.

I put this into an internal package for now in case it needs to mature a bit, but I was thinking that it might be useful to external users as well at some point.