### PR TITLE
feature: add a function to pre-warm the public key cache

### DIFF
--- a/jwtkms/kms_signing_method.go
+++ b/jwtkms/kms_signing_method.go
@@ -4,7 +4,6 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/x509"
 	"encoding/asn1"
 	"fmt"
 	"math/big"
@@ -156,19 +155,11 @@ func (m *KMSSigningMethod) Verify(signingString string, sig []byte, keyConfig an
 
 	cachedKey := pubkeyCache.Get(cfg.kmsKeyID)
 	if cachedKey == nil {
-		getPubKeyOutput, err := cfg.kmsClient.GetPublicKey(cfg.ctx, &kms.GetPublicKeyInput{
-			KeyId: aws.String(cfg.kmsKeyID),
-		})
+		var err error
+		cachedKey, err = fetchAndCachePublicKey(cfg.ctx, cfg.kmsClient, cfg.kmsKeyID)
 		if err != nil {
-			return fmt.Errorf("kms get public key: %w", err)
+			return err
 		}
-
-		cachedKey, err = x509.ParsePKIXPublicKey(getPubKeyOutput.PublicKey)
-		if err != nil {
-			return fmt.Errorf("parsing kms public key: %w", err)
-		}
-
-		pubkeyCache.Add(cfg.kmsKeyID, cachedKey)
 	}
 
 	return m.fallbackSigningMethod.Verify(signingString, sig, cachedKey)

--- a/jwtkms/warm.go
+++ b/jwtkms/warm.go
@@ -1,0 +1,46 @@
+package jwtkms
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+)
+
+// fetchAndCachePublicKey retrieves keyID's public key from KMS, parses it, and
+// stores it in the process-wide public key cache used for local (non-KMS)
+// verification. It is shared by KMSSigningMethod.Verify's cache-miss path and
+// WarmPubKeyCache.
+func fetchAndCachePublicKey(ctx context.Context, client KMSClient, keyID string) (crypto.PublicKey, error) {
+	out, err := client.GetPublicKey(ctx, &kms.GetPublicKeyInput{
+		KeyId: aws.String(keyID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("kms get public key: %w", err)
+	}
+
+	pubKey, err := x509.ParsePKIXPublicKey(out.PublicKey)
+	if err != nil {
+		return nil, fmt.Errorf("parsing kms public key: %w", err)
+	}
+
+	pubkeyCache.Add(keyID, pubKey)
+	return pubKey, nil
+}
+
+// WarmPubKeyCache eagerly fetches keyID's public key from KMS and stores it in
+// the process-wide public key cache, returning any error from the KMS call or
+// key parsing.
+//
+// Call this at process startup for every KMS key ID used with
+// verifyWithKMS=false so a bad key ID or a missing kms:GetPublicKey IAM
+// permission fails fast at boot instead of on the first Verify call. Without
+// this, KMSSigningMethod.Verify fetches and caches the key lazily on first
+// use, so a misconfiguration is only discovered when the first token arrives.
+func WarmPubKeyCache(ctx context.Context, client KMSClient, keyID string) error {
+	_, err := fetchAndCachePublicKey(ctx, client, keyID)
+	return err
+}

--- a/jwtkms/warm_test.go
+++ b/jwtkms/warm_test.go
@@ -1,0 +1,100 @@
+package jwtkms
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/matelang/jwt-go-aws-kms/v2/jwtkms/internal/mockkms"
+)
+
+func TestWarmPubKeyCache(t *testing.T) {
+	t.Cleanup(ClearPubKeyCache)
+
+	kms := mockkms.NewMockKMS()
+	id, err := kms.GenerateKey(mockkms.KeyTypeRSA2048)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	if pubkeyCache.Get(id) != nil {
+		t.Fatal("expected cache miss before warming")
+	}
+
+	if err := WarmPubKeyCache(context.Background(), kms, id); err != nil {
+		t.Fatalf("WarmPubKeyCache: %v", err)
+	}
+
+	if pubkeyCache.Get(id) == nil {
+		t.Fatal("expected cache hit after warming")
+	}
+}
+
+func TestWarmPubKeyCache_NonExistentKey(t *testing.T) {
+	t.Cleanup(ClearPubKeyCache)
+
+	kms := mockkms.NewMockKMS()
+
+	err := WarmPubKeyCache(context.Background(), kms, "non-existent-key-id")
+	if err == nil {
+		t.Fatal("expected error warming cache for non-existent key")
+	}
+	if !strings.Contains(err.Error(), "no such key") {
+		t.Errorf("expected 'no such key' error, got: %v", err)
+	}
+
+	if pubkeyCache.Get("non-existent-key-id") != nil {
+		t.Fatal("expected no cache entry after failed warm")
+	}
+}
+
+func TestWarmPubKeyCache_SkipsKMSOnSubsequentVerify(t *testing.T) {
+	t.Cleanup(ClearPubKeyCache)
+
+	underlying := mockkms.NewMockKMS()
+	id, err := underlying.GenerateKey(mockkms.KeyTypeECCNISTP256)
+	if err != nil {
+		t.Fatalf("generating key: %v", err)
+	}
+
+	// Sign a real token before wrapping the client, so its GetPublicKey can be
+	// disabled below without affecting Sign.
+	token := jwt.NewWithClaims(SigningMethodECDSA256, &jwt.MapClaims{"claim": "value"})
+	signed, err := token.SignedString(NewKMSConfig(underlying, id, false))
+	if err != nil {
+		t.Fatalf("signing token: %v", err)
+	}
+
+	if err := WarmPubKeyCache(context.Background(), underlying, id); err != nil {
+		t.Fatalf("WarmPubKeyCache: %v", err)
+	}
+	if pubkeyCache.Get(id) == nil {
+		t.Fatal("expected cache hit after warming")
+	}
+
+	// Verifying through a client whose GetPublicKey always fails proves the
+	// warmed cache entry is used instead of fetching again.
+	client := &failingGetPublicKeyKMS{MockKMS: underlying}
+	config := NewKMSConfig(client, id, false)
+
+	var claims jwt.MapClaims
+	_, err = jwt.ParseWithClaims(signed, &claims, func(*jwt.Token) (any, error) {
+		return config, nil
+	})
+	if err != nil {
+		t.Fatalf("expected verify to succeed using warmed cache, got: %v", err)
+	}
+}
+
+// failingGetPublicKeyKMS wraps a KMSClient and fails any GetPublicKey call, to
+// prove Verify uses the pre-warmed cache instead of fetching again.
+type failingGetPublicKeyKMS struct {
+	*mockkms.MockKMS
+}
+
+func (f *failingGetPublicKeyKMS) GetPublicKey(context.Context, *kms.GetPublicKeyInput, ...func(*kms.Options)) (*kms.GetPublicKeyOutput, error) {
+	return nil, fmt.Errorf("GetPublicKey should not be called")
+}


### PR DESCRIPTION
## What

- extract fetching and caching of public keys to a separate function
- add a new WarmPubKeyCache function that can be called to cache public key on startup, which will error if the key is not available (because, for example, IAM roles/key policy are not set up correctly)

## Why

- when using the library I would like to fail loudly on startup if the service doesn't have access to the public key for verification

## How

- mostly not new code, just moving fetch/cache of public keys to its own function and adding the `WarmPubKeyCache` function

## Backward compatibility

- this is a new function for the API, and shouldn't cause issues for folks who don't use it

## Test plan

- [x] `go test -race ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] `govulncheck ./...` passes
- [x] New code paths have tests
- [x] Public-API changes are documented in README.md

## Security

This _sort of_ affects public key handling, but the code handling the certificates is basically identical, just pushed out to a function call. 

- [x] This change does not affect signing, verification, or key handling
- [ ] OR: I have flagged the maintainer to review the security implications